### PR TITLE
Android 6 Bluetooth fix

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -24,6 +24,7 @@
     <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
     <uses-permission android:name="android.permission.BLUETOOTH" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
 	<uses-sdk android:minSdkVersion="7" android:targetSdkVersion="16"></uses-sdk>
 </manifest> 


### PR DESCRIPTION
To make this great app for lego NXT owners usable on Android 6+